### PR TITLE
Don't modify precursor mz when massOffset is introduced as a tag

### DIFF
--- a/lib/LibraryParserv2.R
+++ b/lib/LibraryParserv2.R
@@ -358,9 +358,6 @@ rm(HeaderLists)
    seqCharge$mZ <- PrecursorMasses
    names(seqCharge) <- c("Sequence", "charge", "mZ")
    joined <-dplyr::left_join(seqCharge, read.csv(massOffset$datapath),by = "Sequence")
-   joined$mZ[!is.na(joined$massOffset )] <- as.numeric(joined$mZ[!is.na(joined$massOffset )])+
-     (joined$massOffset[!is.na(joined$massOffset )])/as.numeric(joined$charge[!is.na(joined$massOffset )])
-   
    joined$massOffsetTag<- ""
    joined$massOffsetTag[!is.na(joined$massOffset)] <- paste0("massOffset:",joined$massOffset[!is.na(joined$massOffset)])
     Tags<-paste0(joined$massOffsetTag," mods:",Modsoutput," ", "ions:", PeakAnnotations )

--- a/lib/SkylineConvert.R
+++ b/lib/SkylineConvert.R
@@ -48,8 +48,6 @@ if(length(massOffset) != 0){
   seqCharge <- data.frame(Sequence=SpectraTable$peptideSeq, charge =SpectraTable$precursorCharge, mZ= SpectraTable$precursorMZ )
 
   joined <-dplyr::left_join(seqCharge, read.csv(massOffset$datapath),by = "Sequence")
-  joined$mZ[!is.na(joined$massOffset )] <- as.numeric(joined$mZ[!is.na(joined$massOffset )])+
-    (joined$massOffset[!is.na(joined$massOffset )])/as.numeric(joined$charge[!is.na(joined$massOffset )])
   
   joined$massOffsetTag<- ""
   joined$massOffsetTag[!is.na(joined$massOffset)] <- paste0("massOffset:",joined$massOffset[!is.na(joined$massOffset)])

--- a/lib/SkylineConvert.R
+++ b/lib/SkylineConvert.R
@@ -19,7 +19,7 @@ OrganizePeaks<- function(x,topX,cutoff) {
   dt<-setkey(dt, masses)
   return(dt)
 }
-SkylineConvert<- function(x,CollisionEnergy,FragmentationMode,MassAnalyzer,topX,cutoff, Filter,massOffset, DBoutput) {
+SkylineConvert<- function(x,CollisionEnergy,CompoundClassArg,FragmentationMode,MassAnalyzer,topX,cutoff, Filter,massOffset, DBoutput) {
 
 
 blib<-dbConnect(SQLite(),x)
@@ -58,6 +58,15 @@ else {
 
 }
 
+  # Handle mapping of compound class:
+  mappedCompoundClasses = ""
+  if(length(CompoundClassArg) != 0)
+  {
+  seqCharge <- data.frame(Sequence=SpectraTable$peptideSeq, charge =SpectraTable$precursorCharge, mZ= SpectraTable$precursorMZ )
+   joined <-dplyr::left_join(seqCharge, read.csv(CompoundClassArg$datapath),by = "Sequence")
+   mappedCompoundClasses<-joined$CompoundClass
+  }
+
 
 
 MasterCompoundTable <- data.table(
@@ -74,7 +83,7 @@ MasterCompoundTable <- data.table(
   PubChemId= "",
   Structure= "",
   mzCloudId= as.integer(NA),
-  CompoundClass= "",
+  CompoundClass= mappedCompoundClasses,
   SmilesDescription= "",
   InChiKey= "")
 

--- a/lib/SpXLibraryParser.R
+++ b/lib/SpXLibraryParser.R
@@ -163,7 +163,7 @@ MonoisotopicMass <- function(formula = list(), isotopes = list(), charge = 0) {
 
 
 
-SpXLibraryParser <- function(Library, FragmentationMode, MassAnalyzer, CollisionEnergy, 
+SpXLibraryParser <- function(Library, FragmentationMode, MassAnalyzer, CollisionEnergy, CompoundClassArg,
                              Filter=TRUE, TMTPro, Source, topX=0, cutoff=0,massOffset=NULL, IonTypes=NULL) {
   
   
@@ -330,10 +330,20 @@ SpXLibraryParser <- function(Library, FragmentationMode, MassAnalyzer, Collision
   Names <- gsub("[[:lower:]]", "", Names)
   Names<- paste0(Names, "/", Charge)
   
+  # Handle mapping of compound class:
+  mappedCompoundClasses = ""
+  if(length(CompoundClassArg) != 0)
+  {
+   seqCharge <- data.frame(tstrsplit(Names, "/"))
+   names(seqCharge) <- c("Sequence", "charge")
+   joined <-dplyr::left_join(seqCharge, read.csv(CompoundClassArg$datapath),by = "Sequence")
+   mappedCompoundClasses<-joined$CompoundClass
+  }
+
   parallelTable<- data.table(blobMass=blobMass, blobInt=blobInt, 
                              CompoundClass = "Yeast", Formula = Modsoutput, 
                              PrecursorMasses=PrecursorMasses,Names=Names,Tags=Tags, FragmentationMode=FragmentationMode,
-                             CollisionEnergy=CollisionEnergy,
+                             CollisionEnergy=CollisionEnergy, CompoundClass=mappedCompoundClasses,
                              iRT=RetentionTime, seq=sequence, z= Charge)
   
   return(parallelTable)

--- a/lib/SpXLibraryParser.R
+++ b/lib/SpXLibraryParser.R
@@ -316,8 +316,6 @@ SpXLibraryParser <- function(Library, FragmentationMode, MassAnalyzer, Collision
     seqCharge$mZ <- PrecursorMasses
     names(seqCharge) <- c("Sequence", "charge", "mZ")
     joined <-dplyr::left_join(seqCharge, read.csv(massOffset$datapath),by = "Sequence")
-    joined$mZ[!is.na(joined$massOffset )] <- as.numeric(joined$mZ[!is.na(joined$massOffset )])+
-      (joined$massOffset[!is.na(joined$massOffset )])/as.numeric(joined$charge[!is.na(joined$massOffset )])
     
     joined$massOffsetTag<- ""
     joined$massOffsetTag[!is.na(joined$massOffset)] <- paste0("massOffset:",joined$massOffset[!is.na(joined$massOffset)])

--- a/lib/msp2db.R
+++ b/lib/msp2db.R
@@ -98,7 +98,7 @@ if(grepl("msp", tolower(fileType))) {
        LibraryParser(Library=Lib$V1, FragmentationMode=FragmentationMode, MassAnalyzer=MassAnalyzer,
                      CollisionEnergy=CollisionEnergy, CompoundClassArg=CompoundClass,
                      Filter=Filter, TMTPro=TMTPro, Source=fileType, topX=topX,
-                     cutoff=cutoff,massOffset=NULL, IonTypes=IonTypes)
+                     cutoff=cutoff,massOffset=massOffset, IonTypes=IonTypes)
      },
      x=NamesListX, y=NamesListY, z=LibraryPath,
      BPPARAM=SnowParam(workers = max(2,parallel::detectCores()-6)),SIMPLIFY = FALSE) %>% bind_rows

--- a/lib/msp2db.R
+++ b/lib/msp2db.R
@@ -54,7 +54,7 @@ if(grepl("msp", tolower(fileType))) {
         Lib<-LibraryRead
        
          resultsTable<- SpXLibraryParser(Library=Lib$V1, FragmentationMode=FragmentationMode, MassAnalyzer=MassAnalyzer,
-                         CollisionEnergy=CollisionEnergy,
+                         CollisionEnergy=CollisionEnergy, CompoundClassArg=CompoundClass,
                          Filter=Filter, TMTPro=TMTPro, Source=fileType, topX=topX,
                          cutoff=cutoff, massOffset = massOffset,  IonTypes=IonTypes)
       
@@ -81,7 +81,7 @@ if(grepl("msp", tolower(fileType))) {
       #Lib<-""
       Lib<-fread(z,skip = x-1, nrows = (y-x), blank.lines.skip=FALSE, sep = "\n",  header = FALSE )
       SpXLibraryParser(Library=Lib$V1, FragmentationMode=FragmentationMode, MassAnalyzer=MassAnalyzer,
-                       CollisionEnergy=CollisionEnergy,
+                       CollisionEnergy=CollisionEnergy, CompoundClassArg=CompoundClass,
                        Filter=Filter, TMTPro=TMTPro, Source=fileType, topX=topX,
                        cutoff=cutoff, massOffset = massOffset,  IonTypes=IonTypes)
     },
@@ -191,7 +191,7 @@ if(grepl("msp", tolower(fileType))) {
    if( fileType == "Skyline") {
     source("~/Repos/MSPtoDB/lib/SkylineConvert.R")
      LibraryPath<-Library$datapath
-SkylineConvert(x=LibraryPath,CollisionEnergy=CollisionEnergy,FragmentationMode=FragmentationMode,MassAnalyzer=MassAnalyzer,topX=topX,cutoff=cutoff, Filter=Filter,massOffset=massOffset, DBoutput=DBoutput)
+SkylineConvert(x=LibraryPath,CollisionEnergy=CollisionEnergy,CompoundClassArg=CompoundClass,FragmentationMode=FragmentationMode,MassAnalyzer=MassAnalyzer,topX=topX,cutoff=cutoff, Filter=Filter,massOffset=massOffset, DBoutput=DBoutput)
 
   }
 }


### PR DESCRIPTION
Mass offset values shouldn't modify the precursor mz.  The dalton offset should be included only as a Tag item, and is used to modify the isolation offset of triggered scans.